### PR TITLE
Fix ngrok auth token variable inconsistency

### DIFF
--- a/src/ngrok.js
+++ b/src/ngrok.js
@@ -7,7 +7,7 @@ import https from "https";
 
 dotenv.config();
 
-const auth = process.env.NGROK_AUTH_TOKEN;
+const auth = process.env.NGROK_AUTHTOKEN;
 
 (async function() {
   try {


### PR DESCRIPTION
Fix inconsistency between .env and code for ngrok auth token variable name. Changed NGROK_AUTH_TOKEN to NGROK_AUTHTOKEN in ngrok.js for consistency with .env.example, preventing potential configuration errors.

Fixes #5